### PR TITLE
fix: add retries to assisted installer API calls

### DIFF
--- a/ansible/roles/host_ocp4_assisted_scale/defaults/main.yml
+++ b/ansible/roles/host_ocp4_assisted_scale/defaults/main.yml
@@ -23,3 +23,8 @@ worker_only: false
 # CSR approval retry settings
 approve_csr_retries: 90
 approve_csr_delay: 10
+
+# Assisted Installer API retry settings
+# SSO token exchange can fail transiently with "invalid_grant"
+ai_api_retries: 5
+ai_api_delay: 30

--- a/ansible/roles/host_ocp4_assisted_scale/tasks/main.yaml
+++ b/ansible/roles/host_ocp4_assisted_scale/tasks/main.yaml
@@ -66,6 +66,9 @@
       offline_token: "{{ ai_offline_token }}"
       owner: true
     register: r_list_clusters
+    retries: "{{ ai_api_retries }}"
+    delay: "{{ ai_api_delay }}"
+    until: r_list_clusters is not failed
 
   - name: Filter the created clusters
     ansible.builtin.set_fact:
@@ -82,6 +85,9 @@
       api_vip_dnsname: "{{ ai_network_prefix + '.100' if current_instance_workers | int > 1 else ai_network_prefix + '.10' }}"
       openshift_cluster_id: "{{ cluster.openshift_cluster_id }}"
     register: r_import_cluster
+    retries: "{{ ai_api_retries }}"
+    delay: "{{ ai_api_delay }}"
+    until: r_import_cluster is not failed
 
   - name: Set base_dns_domain update data
     ansible.builtin.set_fact:
@@ -94,6 +100,10 @@
       offline_token: "{{ ai_offline_token }}"
       cluster_id: "{{ r_import_cluster.result.id }}"
       cluster_update_params: "{{ _update_dns_domain | to_json if _update_dns_domain is mapping else _update_dns_domain }}"
+    register: _r_update_cluster
+    retries: "{{ ai_api_retries }}"
+    delay: "{{ ai_api_delay }}"
+    until: _r_update_cluster is not failed
 
   - name: Generate mac addresses for workers
     ansible.builtin.set_fact:
@@ -121,6 +131,9 @@
       pull_secret: "{{ ai_pull_secret }}"
       static_network_config: "{{ static_network_config }}"
     register: newinfraenv
+    retries: "{{ ai_api_retries }}"
+    delay: "{{ ai_api_delay }}"
+    until: newinfraenv is not failed
 
   - name: Create PVC for the installation ISO
     kubernetes.core.k8s:


### PR DESCRIPTION
## Summary

- Add `retries`/`delay`/`until` wrappers to 4 assisted installer API calls in `host_ocp4_assisted_scale` that previously had no retry logic: `list_clusters`, `import_cluster`, `update_cluster`, `create_infra_env`
- Introduce configurable `ai_api_retries` (default 5) and `ai_api_delay` (default 30s) variables in role defaults, following the same pattern as existing `approve_csr_retries`/`approve_csr_delay`
- `wait_for_hosts` already had retries and is unchanged

## Motivation

Transient SSO `invalid_grant` errors during Red Hat token exchange cause the role to fail immediately at the first API call. With 5 retries × 30s delay, the role tolerates up to 2.5 minutes of SSO instability before failing.

## Test plan

- [ ] Deploy a CNV cluster that uses `host_ocp4_assisted_scale` and verify worker scaling completes
- [ ] Verify overriding `ai_api_retries` / `ai_api_delay` in catalog item vars works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)