### PR TITLE
Add namespace label to operator namespace for OCP 5

### DIFF
--- a/ansible-navigator.yml
+++ b/ansible-navigator.yml
@@ -2,8 +2,7 @@
 ansible-navigator:
   execution-environment:
     container-engine: podman
-#    image: quay.io/agnosticd/ee-multicloud:chained-2026-08-05
-    image: quay.io/agnosticd/ee-multicloud:chained-2026-07-07
+    image: quay.io/agnosticd/ee-multicloud:chained-2026-08-05
     pull:
       policy: missing
   format: json

--- a/ansible/roles/install_operator/tasks/install.yml
+++ b/ansible/roles/install_operator/tasks/install.yml
@@ -18,9 +18,13 @@
   - name: "Ensure Namespace exists ({{ install_operator_name }})"
     kubernetes.core.k8s:
       state: present
-      api_version: v1
-      kind: Namespace
-      name: "{{ install_operator_namespace }}"
+      definition:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: "{{ install_operator_namespace }}"
+          labels:
+            pod-security.kubernetes.io/enforce: privileged 
 
   - name: "Ensure OperatorGroup exists ({{ install_operator_name }})"
     when: not install_operator_skip_operatorgroup | default(false) | bool


### PR DESCRIPTION
##### SUMMARY

For OCP 5 a namespace which hosts an operator needs label 
  pod-security.kubernetes.io/enforce: privileged 

Adding to the namespace.

Also update default chained EE in ansible-navigator to current latest

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
install_operator