### PR TITLE
Bugfix: Client download never used host_ocp4_client_url if specified

### DIFF
--- a/ansible/roles/host_ocp4_assisted_installer/tasks/main.yaml
+++ b/ansible/roles/host_ocp4_assisted_installer/tasks/main.yaml
@@ -1,28 +1,41 @@
 ---
-- name: Set URLs for OpenShift GA releases (specific version)
-  when: (host_ocp4_installer_version | string).split('.') | length >= 3
+- name: Set URL for OpenShift Client to provided URL
+  when: host_ocp4_client_url | default("") | length > 0
   ansible.builtin.set_fact:
-    openshift_client_download_url: >-
+    _host_ocp4_client_url: "{{ host_ocp4_client_url }}"
+
+- name: Set URLs for OpenShift GA releases (specific version)
+  when:
+  - host_ocp4_client_url | default("") | length == 0
+  - (host_ocp4_installer_version | string).split('.') | length >= 3
+  ansible.builtin.set_fact:
+    _host_ocp4_client_url: >-
       {{ '{0}/ocp/{1}/openshift-client-linux-{1}.tar.gz'.format(
         host_ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
         host_ocp4_installer_version
       ) }}
 
 - name: Set URLs for OpenShift GA releases (latest stable)
-  when: (host_ocp4_installer_version | string).split('.') | length == 2
+  when:
+  - host_ocp4_client_url | default("") | length == 0
+  - (host_ocp4_installer_version | string).split('.') | length == 2
   set_fact:
-    openshift_client_download_url: >-
+    _host_ocp4_client_url: >-
       {{ '{0}/ocp/stable-{1}/openshift-client-linux.tar.gz'.format(
         host_ocp4_installer_root_url | default("https://mirror.openshift.com/pub/openshift-v4/clients"),
         host_ocp4_installer_version
       ) }}
+
+- name: Print the OpenShift Client URL
+  ansible.builtin.debug:
+    msg: "OpenShift Client URL: {{ _host_ocp4_client_url }}"
 
 - name: Install the OpenShift CLI on the bastion
   delegate_to: "{{ groups['bastions'][0] }}"
   become: true
   ansible.builtin.unarchive:
     remote_src: true
-    src: "{{ openshift_client_download_url }}"
+    src: "{{ _host_ocp4_client_url }}"
     dest: /usr/bin
     mode: ug=rwx,o=rx
     owner: root

--- a/ansible/roles/host_ocp4_assisted_installer/tasks/print_cluster_info.yml
+++ b/ansible/roles/host_ocp4_assisted_installer/tasks/print_cluster_info.yml
@@ -62,10 +62,10 @@
     data:
       openshift_api_url: "{{ openshift_api_url }}"
       openshift_console_url: "{{ openshift_console_url }}"
-      openshift_client_download_url: "{{ openshift_client_download_url }}"
+      openshift_client_download_url: "{{ _host_ocp4_client_url }}"
       openshift_cluster_ingress_domain: "{{ openshift_cluster_ingress_domain }}"
       openshift_kubeadmin_password: "{{ openshift_kubeadmin_password }}"
     msg: |-
       OpenShift Console: {{ openshift_console_url }}
       OpenShift API for command line 'oc' client: {{ openshift_api_url }}
-      Download oc client from {{ openshift_client_download_url }}
+      Download oc client from {{ _host_ocp4_client_url }}


### PR DESCRIPTION
##### SUMMARY

Assisted Installer never used host_ocp4_client_url if specified.
Fixed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
host_ocp4_assisted_installer