### PR TITLE
fix(host_ocp4_assisted_installer): wait for installation ISO DV before VM create

### DIFF
--- a/ansible/roles/host_ocp4_assisted_installer/tasks/setup_infrastructure.yml
+++ b/ansible/roles/host_ocp4_assisted_installer/tasks/setup_infrastructure.yml
@@ -89,6 +89,17 @@
     wait: true
     wait_timeout: 300
 
+- name: Wait for installation ISO DataVolume to be ready
+  kubernetes.core.k8s_info:
+    api_version: cdi.kubevirt.io/v1beta1
+    kind: DataVolume
+    name: "installation-iso-{{ _cluster_name }}"
+    namespace: "{{ ai_ocp_namespace }}"
+  register: r_installation_iso_dv
+  until: r_installation_iso_dv.resources[0].status.phase == "Succeeded"
+  retries: 60
+  delay: 10
+
 - name: Create three control plane VMs for full cluster
   vars:
     vmname: "{{ ai_ocp_vmname_control_plane_prefix }}-{{ _index }}"


### PR DESCRIPTION
The k8s module wait only confirms the DataVolume object exists, not that
CDI has finished importing the ISO. Control plane VMs can be created before
the installation ISO DataVolume import completes so the PVC has no usable
size info for clones yet.

Wait for phase Succeeded on installation-iso before proceeding to VM creation.

This addresses controller errors such as:
```
DataVolume control-plane-cluster-*-installation-cdrom importer has stopped
running due to an error: source/target size info missing
```