### PR TITLE
fix(host_ocp4_assisted_installer): guard installation ISO DV wait until expression

### DIFF
--- a/ansible/roles/host_ocp4_assisted_installer/tasks/setup_infrastructure.yml
+++ b/ansible/roles/host_ocp4_assisted_installer/tasks/setup_infrastructure.yml
@@ -96,9 +96,16 @@
     name: "installation-iso-{{ _cluster_name }}"
     namespace: "{{ ai_ocp_namespace }}"
   register: r_installation_iso_dv
-  until: r_installation_iso_dv.resources[0].status.phase == "Succeeded"
+  until:
+  - r_installation_iso_dv.resources | length > 0
+  - r_installation_iso_dv.resources[0].status.phase is defined
+  - r_installation_iso_dv.resources[0].status.phase == "Succeeded"
   retries: 60
   delay: 10
+  failed_when:
+  - r_installation_iso_dv.resources | length > 0
+  - r_installation_iso_dv.resources[0].status.phase is defined
+  - r_installation_iso_dv.resources[0].status.phase == "Failed"
 
 - name: Create three control plane VMs for full cluster
   vars:


### PR DESCRIPTION
Follow-up to #207.

prod0 job 161909 failed because the wait task accessed `status.phase` before CDI
populated it. Ansible errored on the first poll instead of retrying:

```
Error while evaluating conditional: object of type 'dict' has no attribute 'phase'
```

The installation ISO DataVolume import completed successfully ~25s later on ocpv01.

Wait until resources exist and `status.phase` is defined before comparing to
`Succeeded`. Fail fast when phase is `Failed`.