### PR TITLE
[ee-multicloud-legacy-rhel] Pin ansible.platform to version: "2.6.20260504"

### DIFF
--- a/tools/execution_environments/ee-multicloud-legacy-rhel/entrypoint.sh
+++ b/tools/execution_environments/ee-multicloud-legacy-rhel/entrypoint.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 # Copyright: (c) 2023, Ansible Project
 # Apache License, Version 2.0 (see LICENSE.md or https://www.apache.org/licenses/LICENSE-2.0)
 

--- a/tools/execution_environments/ee-multicloud-legacy-rhel/requirements.yml
+++ b/tools/execution_environments/ee-multicloud-legacy-rhel/requirements.yml
@@ -39,6 +39,7 @@ collections:
 - name: ansible.hub
   version: ">=1.0,<2"
 - name: ansible.platform
+  version: "2.6.20260504"
 - name: redhat.rhbk
   version: ">=3.0,<4"
 - name: redhat.trusted_profile_analyzer


### PR DESCRIPTION
Latest version of ansible.platform is not compatible with gateway users collection (infra.app_configuration) due async incompatibility