### PR TITLE
Cleanup rosa deploy variables

### DIFF
--- a/ansible/roles/host_ocp4_rosa_install/defaults/main.yml
+++ b/ansible/roles/host_ocp4_rosa_install/defaults/main.yml
@@ -1,16 +1,19 @@
 ---
-# ROSA cluster name
-rosa_cluster_name: "rosa-{{ guid }}"
-
 # ROSA token - must come from secrets
 # rosa_token: ""
 
+# AWS billing account ID (required for ROSA)
+# aws_billing_account_id: ""
+
+# ROSA cluster name
+rosa_cluster_name: "rosa-{{ guid }}"
+
 # Version of ROSA to deploy
-# Options: default, latest, latest-upgrade, or specific (e.g. 4.17.4)
+# Options: default, latest, latest-upgrade, or specific (e.g. 4.22.4)
 rosa_version: default
 
 # Base version string for latest/latest-upgrade resolution
-rosa_version_base: "openshift-v4.20"
+rosa_version_base: openshift-v4.22
 
 # ROSA CLI version and download URL
 rosa_installer_version: latest
@@ -34,22 +37,10 @@ rosa_service_cidr: ""
 rosa_pod_cidr: ""
 rosa_host_prefix: ""
 
-# Set up cluster-admin user
-rosa_setup_cluster_admin: true
-rosa_setup_cluster_admin_login: false
-
 # Terraform for ROSA networking
-rosa_terraform_version: "1.15.3"
+rosa_terraform_version: "1.16.2"
 rosa_terraform_url: >-
   https://releases.hashicorp.com/terraform/{{ rosa_terraform_version }}/terraform_{{ rosa_terraform_version }}_linux_amd64.zip
 rosa_terraform_repo: https://github.com/openshift-cs/terraform-vpc-example
 rosa_terraform_repo_branch: main
 
-# AWS billing account ID (required for ROSA)
-# aws_billing_account_id: ""
-
-# Internal state variables
-_rosa_cluster_admin_password: ""
-_rosa_supported_regions: ""
-_rosa_version_to_install: ""
-_rosa_ocp_cli_version: ""

--- a/ansible/roles/host_ocp4_rosa_install/tasks/main.yml
+++ b/ansible/roles/host_ocp4_rosa_install/tasks/main.yml
@@ -116,13 +116,5 @@
       rosa_openshift_api_url: "{{ rosa_openshift_api_url }}"
       rosa_version: "{{ _rosa_version_to_install }}"
       rosa_cluster_name: "{{ rosa_cluster_name }}"
-
-- name: Save ROSA admin credentials
-  when:
-  - rosa_setup_cluster_admin | bool
-  - _rosa_cluster_admin_password | length > 0
-  delegate_to: localhost
-  agnosticd.core.agnosticd_user_info:
-    data:
       rosa_openshift_admin_user: cluster-admin
       rosa_openshift_admin_password: "{{ _rosa_cluster_admin_password }}"

--- a/ansible/roles/host_ocp4_rosa_install/vars/main.yml
+++ b/ansible/roles/host_ocp4_rosa_install/vars/main.yml
@@ -1,0 +1,6 @@
+---
+# Internal state variables
+_rosa_cluster_admin_password: ""
+_rosa_supported_regions: ""
+_rosa_version_to_install: ""
+_rosa_ocp_cli_version: ""


### PR DESCRIPTION
##### SUMMARY

During the port of the Rosa deployment method a few variables were moved that have no implementation.
A cluster admin always has to be created for any post install config to work.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
host_ocp4_rosa_install